### PR TITLE
Use unicorn

### DIFF
--- a/lib/capistrano-unicorn/capistrano_integration.rb
+++ b/lib/capistrano-unicorn/capistrano_integration.rb
@@ -23,7 +23,7 @@ module CapistranoUnicorn
             config_path = "#{current_path}/config/unicorn/#{unicorn_env}.rb"
             if remote_file_exists?(config_path)
               logger.important("Starting...")
-              run "cd #{current_path} && bundle exec unicorn_rails -c #{config_path} -E #{unicorn_env} -D"
+              run "cd #{current_path} && bundle exec unicorn -c #{config_path} -E #{unicorn_env} -D"
             else
               logger.important("Config file for \"#{unicorn_env}\" environment was not found at \"#{config_path}\"", "Unicorn")
             end
@@ -58,7 +58,7 @@ module CapistranoUnicorn
               logger.important("No PIDs found. Starting Unicorn server...", "Unicorn")
               config_path = "#{current_path}/config/unicorn/#{unicorn_env}.rb"
               if remote_file_exists?(config_path)
-                run "cd #{current_path} && bundle exec unicorn_rails -c #{config_path} -E #{unicorn_env} -D"
+                run "cd #{current_path} && bundle exec unicorn -c #{config_path} -E #{unicorn_env} -D"
               else
                 logger.important("Config file for \"#{unicorn_env}\" environment was not found at \"#{config_path}\"", "Unicorn")
               end              


### PR DESCRIPTION
Hi Dan,

There wasn't a specific problem, I had just read this from http://unicorn.bogomips.org/unicorn_rails_1.html and thought I would follow the suggestion:

Rails 3 users are encouraged to use unicorn(1) instead of unicorn_rails(1). Users of Rails 1.x/2.y may also use unicorn(1) instead of unicorn_rails(1).

A small change for sure.  Thanks anyway!  :)

Chip
