### PR TITLE
let unicorn read the right Gemfile on USR2

### DIFF
--- a/lib/capistrano-unicorn/capistrano_integration.rb
+++ b/lib/capistrano-unicorn/capistrano_integration.rb
@@ -23,7 +23,7 @@ module CapistranoUnicorn
             config_path = "#{current_path}/config/unicorn/#{unicorn_env}.rb"
             if remote_file_exists?(config_path)
               logger.important("Starting...", "Unicorn")
-              run "cd #{current_path} && bundle exec unicorn -c #{config_path} -E #{unicorn_env} -D"
+              run "cd #{current_path} && BUNDLE_GEMFILE=#{current_path}/Gemfile bundle exec unicorn -c #{config_path} -E #{unicorn_env} -D"
             else
               logger.important("Config file for \"#{unicorn_env}\" environment was not found at \"#{config_path}\"", "Unicorn")
             end


### PR DESCRIPTION
since unicorn knows Gemfile path in its real (not symbolic) one, it continues to use old Gemfile after receiving USR2.
my patch fixes this issue by specifying Gemfile in `current_path' (symbolic) via BUNDLE_GEMFILE environment variable.
