### PR TITLE
app environment independent of unicorn environment

### DIFF
--- a/lib/capistrano-unicorn/capistrano_integration.rb
+++ b/lib/capistrano-unicorn/capistrano_integration.rb
@@ -5,7 +5,7 @@ module CapistranoUnicorn
   class CapistranoIntegration
     def self.load_into(capistrano_config)
       capistrano_config.load do
-        
+
         # Check if remote file exists
         #
         def remote_file_exists?(full_path)
@@ -15,20 +15,21 @@ module CapistranoUnicorn
         # Set unicorn vars
         #
         _cset(:unicorn_pid, "#{fetch(:current_path)}/tmp/pids/unicorn.pid")
-        _cset(:unicorn_env, (fetch(:rails_env) rescue 'production'))
-  
+        _cset(:app_env, (fetch(:rails_env) rescue 'production'))
+        _cset(:unicorn_env, (fetch(:app_env)))
+
         namespace :unicorn do
           desc 'Start Unicorn'
           task :start, :roles => :app, :except => {:no_release => true} do
             config_path = "#{current_path}/config/unicorn/#{unicorn_env}.rb"
             if remote_file_exists?(config_path)
               logger.important("Starting...", "Unicorn")
-              run "cd #{current_path} && BUNDLE_GEMFILE=#{current_path}/Gemfile bundle exec unicorn -c #{config_path} -E #{unicorn_env} -D"
+              run "cd #{current_path} && BUNDLE_GEMFILE=#{current_path}/Gemfile bundle exec unicorn -c #{config_path} -E #{app_env} -D"
             else
               logger.important("Config file for \"#{unicorn_env}\" environment was not found at \"#{config_path}\"", "Unicorn")
             end
           end
-          
+
           desc 'Stop Unicorn'
           task :stop, :roles => :app, :except => {:no_release => true} do
             if remote_file_exists?(unicorn_pid)
@@ -58,11 +59,11 @@ module CapistranoUnicorn
               logger.important("No PIDs found. Starting Unicorn server...", "Unicorn")
               config_path = "#{current_path}/config/unicorn/#{unicorn_env}.rb"
               if remote_file_exists?(config_path)
-                run "cd #{current_path} && bundle exec unicorn -c #{config_path} -E #{unicorn_env} -D"
+                run "cd #{current_path} && bundle exec unicorn -c #{config_path} -E #{app_env} -D"
               else
                 logger.important("Config file for \"#{unicorn_env}\" environment was not found at \"#{config_path}\"", "Unicorn")
-              end              
-            end 
+              end
+            end
           end
         end
 


### PR DESCRIPTION
useful for multistage deployments:
i.e. unicorn-config differs between staging and production servers but
the app should run in production environment on both.

Would you mind integrating this change into yours.

Kind regards, tehael
