### PR TITLE
Specify BUNDLE_GEMFILE in reload task

### DIFF
--- a/lib/capistrano-unicorn/capistrano_integration.rb
+++ b/lib/capistrano-unicorn/capistrano_integration.rb
@@ -59,7 +59,7 @@ module CapistranoUnicorn
               logger.important("No PIDs found. Starting Unicorn server...", "Unicorn")
               config_path = "#{current_path}/config/unicorn/#{unicorn_env}.rb"
               if remote_file_exists?(config_path)
-                run "cd #{current_path} && bundle exec unicorn -c #{config_path} -E #{app_env} -D"
+                run "cd #{current_path} && BUNDLE_GEMFILE=#{current_path}/Gemfile bundle exec unicorn -c #{config_path} -E #{app_env} -D"
               else
                 logger.important("Config file for \"#{unicorn_env}\" environment was not found at \"#{config_path}\"", "Unicorn")
               end


### PR DESCRIPTION
An earlier patch adds a partial fix to a problem with Unicorn not properly updating it's gem list when receiving the USR2 signal. The problem was that the new Gemfile is not read by Unicorn. One fix for this is to specify the Gemfile explicitly in the startup command for Unicorn using BUNDLE_GEMFILE, and using a symbolically linked path so that it will still find the right Gemfile after a deploy. 

This problem is discussed a little here: http://davidvollbracht.com/blog/headachenewunicorn-capistrano-bundler-usr2 , and here: http://unicorn.bogomips.org/Sandbox.html .

The earlier patch adds this fix to the start task. However, this still leaves issues if the reload task is called while Unicorn is not running. This starts the server with a separate command that didn't specify the BUNDLE_GEMFILE, so that later reloads may not properly update gems. This patch fixes that bug.

Great gem, by the way!
