### PR TITLE
Unicorn restart

### DIFF
--- a/capistrano-unicorn.gemspec
+++ b/capistrano-unicorn.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{|f| File.basename(f)}
   gem.require_paths = ['lib']
-  
+
   gem.add_runtime_dependency 'capistrano'
+  gem.add_development_dependency 'rake'
 end


### PR DESCRIPTION
This should address issue #8

It uses the staging mechanism for restarting unicorn, complete with fallbacks.  The only thing better would be if it detected the port and did a quick curl to the port to verify it is working...though that could be problematic.
