### PR TITLE
Unicorn config selection

### DIFF
--- a/lib/capistrano-unicorn/capistrano_integration.rb
+++ b/lib/capistrano-unicorn/capistrano_integration.rb
@@ -92,7 +92,7 @@ module CapistranoUnicorn
             end
           end
 
-          task :restart => :reload
+          alias_task :restart, :reload
         end
 
         after "deploy:restart", "unicorn:reload"


### PR DESCRIPTION
A lot of folks using Unicorn do not use environment specific unicorn configuration files. Instead, they use a single file located directly under their project's config dir ( i.e. config/unicorn.rb ). This change allows for people to follow that convention but also maintains compatibility with env-specific files.
