### PR TITLE
Adds process check for :reload task

### DIFF
--- a/lib/capistrano-unicorn/capistrano_integration.rb
+++ b/lib/capistrano-unicorn/capistrano_integration.rb
@@ -78,7 +78,7 @@ module CapistranoUnicorn
 
           desc 'Reload Unicorn'
           task :reload, :roles => :app, :except => {:no_release => true} do
-            if remote_file_exists?(unicorn_pid)
+            if remote_file_exists?(unicorn_pid) && remote_process_exists?(unicorn_pid)
               logger.important("Stopping...", "Unicorn")
               run "#{try_sudo} kill -s USR2 `cat #{unicorn_pid}`"
             else


### PR DESCRIPTION
When performing an upgrade, it does not suffice to simply check for the unicorn PID file.
We also need to check for process existence because sometimes unicorn can die and leave behind
a stale PID file. In this case, we should issue a 'start' cmd.
