### PR TITLE
:reload now does HUP instead of USR2

### DIFF
--- a/lib/capistrano-unicorn/capistrano_integration.rb
+++ b/lib/capistrano-unicorn/capistrano_integration.rb
@@ -98,7 +98,13 @@ module CapistranoUnicorn
               logger.important("Reloading...", "Unicorn")
               run "#{try_sudo} kill -s HUP `cat #{unicorn_pid}`"
             else
-              logger.important("No PIDs found. Check if unicorn is running.", "Unicorn")
+              logger.important("No PIDs found. Starting Unicorn server...", "Unicorn")
+              config_path = "#{current_path}/config/unicorn/#{unicorn_env}.rb"
+              if remote_file_exists?(config_path)
+                run "cd #{current_path} && BUNDLE_GEMFILE=#{current_path}/Gemfile bundle exec #{unicorn_bin} -c #{config_path} -E #{app_env} -D"
+              else
+                logger.important("Config file for \"#{unicorn_env}\" environment was not found at \"#{config_path}\"", "Unicorn")
+              end
             end
           end
         end

--- a/lib/capistrano-unicorn/capistrano_integration.rb
+++ b/lib/capistrano-unicorn/capistrano_integration.rb
@@ -29,7 +29,7 @@ module CapistranoUnicorn
           desc 'Start Unicorn'
           task :start, :roles => :app, :except => {:no_release => true} do
             if remote_file_exists?(unicorn_pid)
-              if process_exists?(unicorn_pid)
+              if remote_process_exists?(unicorn_pid)
                 logger.important("Unicorn is already running!", "Unicorn")
                 next
               else

--- a/lib/capistrano-unicorn/capistrano_integration.rb
+++ b/lib/capistrano-unicorn/capistrano_integration.rb
@@ -76,8 +76,8 @@ module CapistranoUnicorn
             end
           end
 
-          desc 'Reload Unicorn'
-          task :reload, :roles => :app, :except => {:no_release => true} do
+          desc 'Restart Unicorn'
+          task :restart, :roles => :app, :except => {:no_release => true} do
             if remote_file_exists?(unicorn_pid)
               logger.important("Stopping...", "Unicorn")
               run "#{try_sudo} kill -s USR2 `cat #{unicorn_pid}`"
@@ -92,7 +92,15 @@ module CapistranoUnicorn
             end
           end
 
-          task :restart => :reload
+          desc 'Reload Unicorn'
+          task :reload, :roles => :app, :except => {:no_release => true} do
+            if remote_file_exists?(unicorn_pid)
+              logger.important("Reloading...", "Unicorn")
+              run "#{try_sudo} kill -s HUP `cat #{unicorn_pid}`"
+            else
+              logger.important("No PIDs found. Check if unicorn is running.", "Unicorn")
+            end
+          end
         end
 
         after "deploy:restart", "unicorn:reload"


### PR DESCRIPTION
In every environment I've worked on with unicorn, we've sent a HUP signal to unicorn instead of USR2, to do a "hot reload" of the application. To that end, I've made the :reload task send a HUP, and left USR2 in the restart task.

I think this should be the default behavior, so I've left the line

```
after "deploy:restart", "unicorn:reload"
```

as is. Thoughts on this?
