### PR TITLE
fix for unicorn_env always being production

### DIFF
--- a/lib/capistrano-unicorn/capistrano_integration.rb
+++ b/lib/capistrano-unicorn/capistrano_integration.rb
@@ -33,7 +33,9 @@ module CapistranoUnicorn
 
         # Set unicorn vars
         #
-        before [ 'unicorn:start', 'unicorn:stop', 'unicorn:graceful_stop', 'unicorn:reload' ] do
+        before [ 'unicorn:start', 'unicorn:stop', 'unicorn:shutdown', 
+                 'unicorn:restart', 'unicorn:reload', 'unicorn:add_worker',  
+                 'unicorn:remove_worker' ] do
           _cset(:unicorn_pid, "#{fetch(:current_path)}/tmp/pids/unicorn.pid")
           _cset(:app_env, (fetch(:rails_env) rescue 'production'))
           _cset(:unicorn_env, (fetch(:app_env)))

--- a/lib/capistrano-unicorn/capistrano_integration.rb
+++ b/lib/capistrano-unicorn/capistrano_integration.rb
@@ -31,13 +31,14 @@ module CapistranoUnicorn
           run "#{try_sudo} kill -s #{signal} #{pid}"
         end
 
-        #
         # Set unicorn vars
         #
-        _cset(:unicorn_pid, "#{fetch(:current_path)}/tmp/pids/unicorn.pid")
-        _cset(:app_env,     (fetch(:rails_env) rescue 'production'))
-        _cset(:unicorn_env, (fetch(:app_env)))
-        _cset(:unicorn_bin, "unicorn")
+        before [ 'unicorn:start', 'unicorn:stop', 'unicorn:graceful_stop', 'unicorn:reload' ] do
+          _cset(:unicorn_pid, "#{fetch(:current_path)}/tmp/pids/unicorn.pid")
+          _cset(:app_env, (fetch(:rails_env) rescue 'production'))
+          _cset(:unicorn_env, (fetch(:app_env)))
+          _cset(:unicorn_bin, "unicorn")
+        end
 
         #
         # Unicorn rake tasks


### PR DESCRIPTION
its important that we give the end-user a chance to run tasks like :local, :development, :production before we attempt to determine the rails_env, app_env, unicorn_env, etc. otherwise its always :production.
