### PR TITLE
Support for running Unicorn as a different user.

### DIFF
--- a/lib/capistrano-unicorn/capistrano_integration.rb
+++ b/lib/capistrano-unicorn/capistrano_integration.rb
@@ -5,68 +5,49 @@ module CapistranoUnicorn
   class CapistranoIntegration
     def self.load_into(capistrano_config)
       capistrano_config.load do
+
         # Check if remote file exists
         #
         def remote_file_exists?(full_path)
           'true' ==  capture("if [ -e #{full_path} ]; then echo 'true'; fi").strip
         end
-
+        
         # Check if process is running
         #
-        def remote_process_exists?(pid_file)
+        def process_exists?(pid_file)
           capture("ps -p $(cat #{pid_file}) ; true").strip.split("\n").size == 2
-        end
-
-        # Get unicorn master process PID
-        #
-        def unicorn_get_pid
-          if remote_file_exists?(unicorn_pid) && remote_process_exists?(unicorn_pid)
-            capture("cat #{unicorn_pid}")
-          end
-        end
-
-        # Send a signal to unicorn master process
-        #
-        def unicorn_send_signal(pid, signal)
-          run "#{try_sudo} kill -s #{signal} #{pid}"
         end
 
         # Set unicorn vars
         #
-        before [ 'unicorn:start', 'unicorn:stop', 'unicorn:shutdown', 
-                 'unicorn:restart', 'unicorn:reload', 'unicorn:add_worker',  
-                 'unicorn:remove_worker' ] do
-          _cset(:unicorn_pid, "#{fetch(:current_path)}/tmp/pids/unicorn.pid")
-          _cset(:app_env, (fetch(:rails_env) rescue 'production'))
-          _cset(:unicorn_env, (fetch(:app_env)))
-          _cset(:unicorn_bin, "unicorn")
-        end
+        _cset(:unicorn_pid, "#{fetch(:current_path)}/tmp/pids/unicorn.pid")
+        _cset(:app_env, (fetch(:rails_env) rescue 'production'))
+        _cset(:unicorn_env, (fetch(:app_env)))
+        _cset(:unicorn_bin, "unicorn")
 
-        #
-        # Unicorn rake tasks
-        #
         namespace :unicorn do
-          desc 'Start Unicorn master process'
+          desc 'Start Unicorn'
           task :start, :roles => :app, :except => {:no_release => true} do
             if remote_file_exists?(unicorn_pid)
-              if remote_process_exists?(unicorn_pid)
+              if process_exists?(unicorn_pid)
                 logger.important("Unicorn is already running!", "Unicorn")
                 next
               else
                 run "rm #{unicorn_pid}"
               end
             end
-
-            primary_config_path = "#{current_path}/config/unicorn.rb"
-            if remote_file_exists?(primary_config_path)
-              config_path = primary_config_path
-            else
-              config_path = "#{current_path}/config/unicorn/#{unicorn_env}.rb"
-            end
-
+            
+            config_path = "#{current_path}/config/unicorn/#{unicorn_env}.rb"
             if remote_file_exists?(config_path)
               logger.important("Starting...", "Unicorn")
-              run "cd #{current_path} && BUNDLE_GEMFILE=#{current_path}/Gemfile bundle exec #{unicorn_bin} -c #{config_path} -E #{app_env} -D"
+
+              unicorn_user = variables[:unicorn_user]
+              if unicorn_user
+                run "cd #{current_path} && #{try_sudo :as => unicorn_user} env PATH=$PATH BUNDLE_GEMFILE=#{current_path}/Gemfile bundle exec #{unicorn_bin} -c #{config_path} -E #{app_env} -D"
+              else
+                run "cd #{current_path} && BUNDLE_GEMFILE=#{current_path}/Gemfile bundle exec #{unicorn_bin} -c #{config_path} -E #{app_env} -D"
+              end
+
             else
               logger.important("Config file for \"#{unicorn_env}\" environment was not found at \"#{config_path}\"", "Unicorn")
             end
@@ -74,72 +55,52 @@ module CapistranoUnicorn
 
           desc 'Stop Unicorn'
           task :stop, :roles => :app, :except => {:no_release => true} do
-            pid = unicorn_get_pid
-            unless pid.nil?
-              logger.important("Stopping...", "Unicorn")
-              unicorn_send_signal(pid, "QUIT")
+            if remote_file_exists?(unicorn_pid)
+              if process_exists?(unicorn_pid)
+                logger.important("Stopping...", "Unicorn")
+                run "#{try_sudo} kill `cat #{unicorn_pid}`"
+              else
+                run "rm #{unicorn_pid}"
+                logger.important("Unicorn is not running.", "Unicorn")
+              end
             else
-              logger.important("Unicorn is not running.", "Unicorn")
+              logger.important("No PIDs found. Check if unicorn is running.", "Unicorn")
             end
           end
 
-          desc 'Immediately shutdown Unicorn'
-          task :shutdown, :roles => :app, :except => {:no_release => true} do
-            pid = unicorn_get_pid
-            unless pid.nil?
-              logger.important("Stopping...", "Unicorn")
-              unicorn_send_signal(pid, "TERM")
+          desc 'Unicorn graceful shutdown'
+          task :graceful_stop, :roles => :app, :except => {:no_release => true} do
+            if remote_file_exists?(unicorn_pid)
+              if process_exists?(unicorn_pid)
+                logger.important("Stopping...", "Unicorn")
+                run "#{try_sudo} kill -s QUIT `cat #{unicorn_pid}`"
+              else
+                run "rm #{unicorn_pid}"
+                logger.important("Unicorn is not running.", "Unicorn")
+              end
             else
-              logger.important("Unicorn is not running.", "Unicorn")
-            end
-          end
-
-          desc 'Restart Unicorn'
-          task :restart, :roles => :app, :except => {:no_release => true} do
-            pid = unicorn_get_pid
-            unless pid.nil?
-              logger.important("Restarting...", "Unicorn")
-              unicorn_send_signal(pid, 'USR2')
-            else
-              unicorn.start
+              logger.important("No PIDs found. Check if unicorn is running.", "Unicorn")
             end
           end
 
           desc 'Reload Unicorn'
           task :reload, :roles => :app, :except => {:no_release => true} do
-            pid = unicorn_get_pid
-            unless pid.nil?
-              logger.important("Reloading...", "Unicorn")
-              unicorn_send_signal(pid, 'HUP')
+            if remote_file_exists?(unicorn_pid)
+              logger.important("Stopping...", "Unicorn")
+              run "#{try_sudo} kill -s USR2 `cat #{unicorn_pid}`"
             else
-              unicorn.start
-            end
-          end
-
-          desc 'Add a new worker'
-          task :add_worker, :roles => :app, :except => {:no_release => true} do
-            pid = unicorn_get_pid
-            unless pid.nil?
-              logger.important("Adding a new worker...", "Unicorn")
-              unicorn_send_signal(pid, "TTIN")
-            else
-              logger.important("Server is not running.", "Unicorn")
-            end
-          end
-
-          desc 'Remove amount of workers'
-          task :remove_worker, :roles => :app, :except => {:no_release => true} do
-            pid = unicorn_get_pid
-            unless pid.nil?
-              logger.important("Removing worker...", "Unicorn")
-              unicorn_send_signal(pid, "TTOU")
-            else
-              logger.important("Server is not running.", "Unicorn")
+              logger.important("No PIDs found. Starting Unicorn server...", "Unicorn")
+              config_path = "#{current_path}/config/unicorn/#{unicorn_env}.rb"
+              if remote_file_exists?(config_path)
+                run "cd #{current_path} && BUNDLE_GEMFILE=#{current_path}/Gemfile bundle exec #{unicorn_bin} -c #{config_path} -E #{app_env} -D"
+              else
+                logger.important("Config file for \"#{unicorn_env}\" environment was not found at \"#{config_path}\"", "Unicorn")
+              end
             end
           end
         end
 
-        after "deploy:restart", "unicorn:restart"
+        after "deploy:restart", "unicorn:reload"
       end
     end
   end

--- a/lib/capistrano-unicorn/capistrano_integration.rb
+++ b/lib/capistrano-unicorn/capistrano_integration.rb
@@ -87,7 +87,8 @@ module CapistranoUnicorn
           task :reload, :roles => :app, :except => {:no_release => true} do
             if remote_file_exists?(unicorn_pid)
               logger.important("Stopping...", "Unicorn")
-              run "#{try_sudo} kill -s USR2 `cat #{unicorn_pid}`"
+              signal = variables[:unicorn_reload_via_sighup] ? 'HUP' : 'USR2'
+              run "#{try_sudo} kill -s #{signal} `cat #{unicorn_pid}`"
             else
               logger.important("No PIDs found. Starting Unicorn server...", "Unicorn")
               config_path = "#{current_path}/config/unicorn/#{unicorn_env}.rb"


### PR DESCRIPTION
Running appservers from within their own, unprivileged user accounts is important for security, so I've added this functionality to capistrano-unicorn.

My pull request doesn't change any of the defaults, so functionality shouldn't change for existing users.

For those that want to run unicorn via sudo, `set :unicorn_user, "appuser"` will do the trick.
