### PR TITLE
Revert default after hook on deploy:restart

### DIFF
--- a/lib/capistrano-unicorn/capistrano_integration.rb
+++ b/lib/capistrano-unicorn/capistrano_integration.rb
@@ -33,8 +33,8 @@ module CapistranoUnicorn
 
         # Set unicorn vars
         #
-        before [ 'unicorn:start', 'unicorn:stop', 'unicorn:shutdown', 
-                 'unicorn:restart', 'unicorn:reload', 'unicorn:add_worker',  
+        before [ 'unicorn:start', 'unicorn:stop', 'unicorn:shutdown',
+                 'unicorn:restart', 'unicorn:reload', 'unicorn:add_worker',
                  'unicorn:remove_worker' ] do
           _cset(:unicorn_pid, "#{fetch(:current_path)}/tmp/pids/unicorn.pid")
           _cset(:app_env, (fetch(:rails_env) rescue 'production'))
@@ -139,7 +139,6 @@ module CapistranoUnicorn
           end
         end
 
-        after "deploy:restart", "unicorn:restart"
       end
     end
   end


### PR DESCRIPTION
I would like to give this flexibility at a higher level. E.g. I would like to execute a `unicorn:reload` instead of `unicorn:restart` after each `deploy:restart`.

Please suggest if there's an easier way to override defaults.
