### PR TITLE
rbenv support

### DIFF
--- a/lib/capistrano-unicorn/capistrano_integration.rb
+++ b/lib/capistrano-unicorn/capistrano_integration.rb
@@ -90,7 +90,7 @@ module CapistranoUnicorn
             fi;
 
             echo "Starting Unicorn...";
-            cd #{current_path} && BUNDLE_GEMFILE=#{current_path}/Gemfile bundle exec #{unicorn_bin} -c $UNICORN_CONFIG_PATH -E #{app_env} -D;
+            cd #{current_path} && BUNDLE_GEMFILE=#{current_path}/Gemfile #{bundle_cmd} exec #{unicorn_bin} -c $UNICORN_CONFIG_PATH -E #{app_env} -D;
           RAINBOW
 
           pot_o_gold


### PR DESCRIPTION
There is a cap variable called **bundle_cmd** which I think should be used. That way the bundle command becomes flexible and can be used by capistrano-rbenv to inject a different command for running bundle (exec)
