### PR TITLE
zero down time on unicorn restart

### DIFF
--- a/lib/capistrano-unicorn/capistrano_integration.rb
+++ b/lib/capistrano-unicorn/capistrano_integration.rb
@@ -16,11 +16,12 @@ module CapistranoUnicorn
     def self.load_into(capistrano_config)
       capistrano_config.load do
         before(CapistranoIntegration::TASKS) do
-          _cset(:app_env)        { (fetch(:rails_env) rescue 'production') }
-          _cset(:unicorn_pid)    { "#{fetch(:current_path)}/tmp/pids/unicorn.pid" }
-          _cset(:unicorn_env)    { fetch(:app_env) }
-          _cset(:unicorn_bin)    { "unicorn" }
-          _cset(:unicorn_bundle) { fetch(:bundle_cmd) rescue 'bundle' }
+          _cset(:app_env)                    { (fetch(:rails_env) rescue 'production') }
+          _cset(:unicorn_pid)                { "#{fetch(:current_path)}/tmp/pids/unicorn.pid" }
+          _cset(:unicorn_env)                { fetch(:app_env) }
+          _cset(:unicorn_bin)                { "unicorn" }
+          _cset(:unicorn_bundle)             { fetch(:bundle_cmd) rescue 'bundle' }
+          _cset(:unicorn_restart_sleep_time) { 2 }
         end
 
         # Check if a remote process exists using its pid file
@@ -143,7 +144,7 @@ module CapistranoUnicorn
                 #{start_unicorn}
               fi;
 
-              sleep 2; # in order to wait for the (old) pidfile to show up
+              sleep #{unicorn_restart_sleep_time}; # in order to wait for the (old) pidfile to show up
 
               if #{old_unicorn_is_running?}; then
                 #{unicorn_send_signal('QUIT', get_old_unicorn_pid)};

--- a/lib/capistrano-unicorn/capistrano_integration.rb
+++ b/lib/capistrano-unicorn/capistrano_integration.rb
@@ -70,6 +70,7 @@ module CapistranoUnicorn
         #
         def kill_unicorn(signal)
           script = <<-END
+            set -x;
             if #{unicorn_is_running?}; then
               echo "Stopping Unicorn...";
               #{unicorn_send_signal(signal)};
@@ -88,6 +89,7 @@ module CapistranoUnicorn
           secondary_config_path = "#{current_path}/config/unicorn/#{unicorn_env}.rb"
 
           script = <<-END
+            set -x;
             if [ -e #{primary_config_path} ]; then
               UNICORN_CONFIG_PATH=#{primary_config_path};
             else
@@ -137,6 +139,7 @@ module CapistranoUnicorn
           desc 'Restart Unicorn'
           task :restart, :roles => :app, :except => {:no_release => true} do
             run <<-END
+              set -x;
               if #{unicorn_is_running?}; then
                 echo "Restarting Unicorn...";
                 #{unicorn_send_signal('USR2')};
@@ -155,6 +158,7 @@ module CapistranoUnicorn
           desc 'Reload Unicorn'
           task :reload, :roles => :app, :except => {:no_release => true} do
             run <<-END
+              set -x;
               if #{unicorn_is_running?}; then
                 echo "Reloading Unicorn...";
                 #{unicorn_send_signal('HUP')};
@@ -167,6 +171,7 @@ module CapistranoUnicorn
           desc 'Add a new worker'
           task :add_worker, :roles => :app, :except => {:no_release => true} do
             run <<-END
+              set -x;
               if #{unicorn_is_running?}; then
                 echo "Adding a new Unicorn worker...";
                 #{unicorn_send_signal('TTIN')};
@@ -179,6 +184,7 @@ module CapistranoUnicorn
           desc 'Remove amount of workers'
           task :remove_worker, :roles => :app, :except => {:no_release => true} do
             run <<-END
+              set -x;
               if #{unicorn_is_running?}; then
                 echo "Removing a Unicorn worker...";
                 #{unicorn_send_signal('TTOU')};


### PR DESCRIPTION
- user can customize the sleep time after USR2 signal
- add `set -x` for verbose information on deploy
