### PR TITLE
Ability to launch Unicorn as a different user than the deployer

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can modify any of the following options in your `deploy.rb` config.
 - `unicorn_pid` - Set unicorn PID file path. Default to `current_path/tmp/pids/unicorn.pid`
 - `unicorn_bin` - Set unicorn executable file. Default to `unicorn`.
 - `unicorn_bundle` - Set bundler command for unicorn. Default to `bundle`.
-- `unicorn_runner` - Launch unicorn master as a different user. Default to `false`. Use `true` to run as Capistrano's `:runner` user (which is `"app"` by default). Use a string to run as the named user. Any non-`false` value requires `set :use_sudo, true`.
+- `unicorn_user` - Launch unicorn master as the specified user. Default to `user` variable.
 
 If you are using capistrano multistage, please refer to [Using capistrano unicorn with multistage environment](https://github.com/sosedoff/capistrano-unicorn/wiki/Using-capistrano-unicorn-with-multistage-environment).
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ You can modify any of the following options in your `deploy.rb` config.
 - `unicorn_pid` - Set unicorn PID file path. Default to `current_path/tmp/pids/unicorn.pid`
 - `unicorn_bin` - Set unicorn executable file. Default to `unicorn`.
 - `unicorn_bundle` - Set bundler command for unicorn. Default to `bundle`.
+- `unicorn_runner` - Launch unicorn master as a different user. Default to `false`. Use `true` to run as Capistrano's `:runner` user (which is `"app"` by default). Use a string to run as the named user. Any non-`false` value requires `set :use_sudo, true`.
 
 If you are using capistrano multistage, please refer to [Using capistrano unicorn with multistage environment](https://github.com/sosedoff/capistrano-unicorn/wiki/Using-capistrano-unicorn-with-multistage-environment).
 

--- a/lib/capistrano-unicorn/capistrano_integration.rb
+++ b/lib/capistrano-unicorn/capistrano_integration.rb
@@ -22,13 +22,13 @@ module CapistranoUnicorn
           _cset(:unicorn_bin)                { "unicorn" }
           _cset(:unicorn_bundle)             { fetch(:bundle_cmd) rescue 'bundle' }
           _cset(:unicorn_restart_sleep_time) { 2 }
-          _cset(:unicorn_runner)             { false }
+          _cset(:unicorn_user)               { nil }
         end
 
         # Check if a remote process exists using its pid file
         #
         def remote_process_exists?(pid_file)
-          "[ -e #{pid_file} ] && #{try_unicorn_runner} kill -0 `cat #{pid_file}` > /dev/null 2>&1"
+          "[ -e #{pid_file} ] && #{try_unicorn_user} kill -0 `cat #{pid_file}` > /dev/null 2>&1"
         end
 
         # Stale Unicorn process pid file
@@ -64,17 +64,14 @@ module CapistranoUnicorn
         # Send a signal to a unicorn master processes
         #
         def unicorn_send_signal(signal, pid=get_unicorn_pid)
-          "#{try_unicorn_runner} kill -s #{signal} #{pid}"
+          "#{try_unicorn_user} kill -s #{signal} #{pid}"
         end
 
-        # Run a command as the :unicorn_runner user if :unicorn_runner is true or a string.
-        # Otherwise run as :user user.
+        # Run a command as the :unicorn_user user if :unicorn_user is a string.
+        # Otherwise run as default (:user) user.
         #
-        def try_unicorn_runner
-          case unicorn_runner
-          when true   then "#{try_runner}"
-          when String then "#{try_sudo :as => unicorn_runner.to_s}"
-          end
+        def try_unicorn_user
+          "#{sudo :as => unicorn_user.to_s}" if unicorn_user.kind_of?(String)
         end
 
         # Kill Unicorns in multiple ways O_O
@@ -113,16 +110,16 @@ module CapistranoUnicorn
             fi;
 
             if [ -e #{unicorn_pid} ]; then
-              if #{try_unicorn_runner} kill -0 `cat #{unicorn_pid}` > /dev/null 2>&1; then
+              if #{try_unicorn_user} kill -0 `cat #{unicorn_pid}` > /dev/null 2>&1; then
                 echo "Unicorn is already running!";
                 exit 0;
               fi;
 
-              #{try_unicorn_runner} rm #{unicorn_pid};
+              #{try_unicorn_user} rm #{unicorn_pid};
             fi;
 
             echo "Starting Unicorn...";
-            cd #{current_path} && #{try_unicorn_runner} BUNDLE_GEMFILE=#{current_path}/Gemfile #{unicorn_bundle} exec #{unicorn_bin} -c $UNICORN_CONFIG_PATH -E #{app_env} -D;
+            cd #{current_path} && #{try_unicorn_user} BUNDLE_GEMFILE=#{current_path}/Gemfile #{unicorn_bundle} exec #{unicorn_bin} -c $UNICORN_CONFIG_PATH -E #{app_env} -D;
           END
 
           script

--- a/lib/capistrano-unicorn/capistrano_integration.rb
+++ b/lib/capistrano-unicorn/capistrano_integration.rb
@@ -22,12 +22,13 @@ module CapistranoUnicorn
           _cset(:unicorn_bin)                { "unicorn" }
           _cset(:unicorn_bundle)             { fetch(:bundle_cmd) rescue 'bundle' }
           _cset(:unicorn_restart_sleep_time) { 2 }
+          _cset(:unicorn_runner)             { false }
         end
 
         # Check if a remote process exists using its pid file
         #
         def remote_process_exists?(pid_file)
-          "[ -e #{pid_file} ] && kill -0 `cat #{pid_file}` > /dev/null 2>&1"
+          "[ -e #{pid_file} ] && #{try_unicorn_runner} kill -0 `cat #{pid_file}` > /dev/null 2>&1"
         end
 
         # Stale Unicorn process pid file
@@ -63,7 +64,17 @@ module CapistranoUnicorn
         # Send a signal to a unicorn master processes
         #
         def unicorn_send_signal(signal, pid=get_unicorn_pid)
-          "#{try_sudo} kill -s #{signal} #{pid}"
+          "#{try_unicorn_runner} kill -s #{signal} #{pid}"
+        end
+
+        # Run a command as the :unicorn_runner user if :unicorn_runner is true or a string.
+        # Otherwise run as :user user.
+        #
+        def try_unicorn_runner
+          case unicorn_runner
+          when true   then "#{try_runner}"
+          when String then "#{try_sudo :as => unicorn_runner.to_s}"
+          end
         end
 
         # Kill Unicorns in multiple ways O_O
@@ -102,16 +113,16 @@ module CapistranoUnicorn
             fi;
 
             if [ -e #{unicorn_pid} ]; then
-              if kill -0 `cat #{unicorn_pid}` > /dev/null 2>&1; then
+              if #{try_unicorn_runner} kill -0 `cat #{unicorn_pid}` > /dev/null 2>&1; then
                 echo "Unicorn is already running!";
                 exit 0;
               fi;
 
-              rm #{unicorn_pid};
+              #{try_unicorn_runner} rm #{unicorn_pid};
             fi;
 
             echo "Starting Unicorn...";
-            cd #{current_path} && BUNDLE_GEMFILE=#{current_path}/Gemfile #{unicorn_bundle} exec #{unicorn_bin} -c $UNICORN_CONFIG_PATH -E #{app_env} -D;
+            cd #{current_path} && #{try_unicorn_runner} BUNDLE_GEMFILE=#{current_path}/Gemfile #{unicorn_bundle} exec #{unicorn_bin} -c $UNICORN_CONFIG_PATH -E #{app_env} -D;
           END
 
           script


### PR DESCRIPTION
With this change, capistrano-unicorn can run Unicorn master (and there Unicorn slaves) as a different user than the deployer.

Sometimes people prefer to use a privileged user for deploying apps and a less-privileged user for running apps. With this change, they can. Here's how:

``` ruby
set :unicorn_runner, true   # Run Unicorn as the :runner user ("app" by default)
set :use_sudo, true         # So deployer can launch Unicorn as the :runner user
# set :runner, "web"        # Optionally override Capistrano's :runner variable
```

This feature relies on Capistrano's existing `:runner` setting, which is the name of the user who will be running the web app. It defaults to `"app"` but can be overridden with `set :runner, "username"`. 

Or you can use a string to choose which user rather than relying on Capistrano's `:runner`:

``` ruby
set :unicorn_runner, "web"   # Run Unicorn as the "web" user
set :use_sudo, true          # So deployer can launch Unicorn as the :runner user
```

The new `unicorn_runner` setting defaults to `false`, keeping is the existing behavior of capistrano-unicorn.

Resolves issue sosedoff/capistrano-unicorn#22.
