### PR TITLE
Allow to defined arbitrary options for unicorn

### DIFF
--- a/lib/capistrano-unicorn/capistrano_integration.rb
+++ b/lib/capistrano-unicorn/capistrano_integration.rb
@@ -21,6 +21,7 @@ module CapistranoUnicorn
           _cset(:unicorn_pid)                { "#{fetch(:current_path)}/tmp/pids/unicorn.pid" }
           _cset(:unicorn_env)                { fetch(:app_env) }
           _cset(:unicorn_bin)                { "unicorn" }
+          _cset(:unicorn_options)            { fetch(:unicorn_options) rescue '' }
           _cset(:unicorn_bundle)             { fetch(:bundle_cmd) rescue 'bundle' }
           _cset(:unicorn_restart_sleep_time) { 2 }
           _cset(:unicorn_user)               { nil }
@@ -120,7 +121,7 @@ module CapistranoUnicorn
             fi;
 
             echo "Starting Unicorn...";
-            cd #{current_path} && #{try_unicorn_user} BUNDLE_GEMFILE=#{current_path}/Gemfile #{unicorn_bundle} exec #{unicorn_bin} -c $UNICORN_CONFIG_PATH -E #{app_env} -D;
+            cd #{current_path} && #{try_unicorn_user} BUNDLE_GEMFILE=#{current_path}/Gemfile #{unicorn_bundle} exec #{unicorn_bin} #{unicorn_options} -c $UNICORN_CONFIG_PATH -E #{app_env} -D;
           END
 
           script


### PR DESCRIPTION
Scenario: One wants to run multiple instances of the same application (e. g. staging and production).

Solution in current master: Move config/unicorn.rb to config/unicorn/staging.rb and config/unicorn/production.rb and use different listen statements. I think this is ugly since 99 % of those files will be duplication and you will need another one for development. So you probably duplicate your unicorn configuration to at least three files.

Solution with this patch: set :unicorn_options, '--host 127.0.0.1 --port 8001' for one stage and set :unicorn_options, '--host 127.0.0.1 --port 8002' for the other one.

The underlying problem is that environment-specific configuration files for unicorn do not include a common configuration file, while for capistrano they do.
