### PR TITLE
Don't send debugging to stderr

### DIFF
--- a/lib/capistrano-unicorn/capistrano_integration.rb
+++ b/lib/capistrano-unicorn/capistrano_integration.rb
@@ -79,7 +79,6 @@ module CapistranoUnicorn
         #
         def kill_unicorn(signal)
           script = <<-END
-            set -x;
             if #{unicorn_is_running?}; then
               echo "Stopping Unicorn...";
               #{unicorn_send_signal(signal)};
@@ -98,7 +97,6 @@ module CapistranoUnicorn
           secondary_config_path = "#{current_path}/config/unicorn/#{unicorn_env}.rb"
 
           script = <<-END
-            set -x;
             if [ -e #{primary_config_path} ]; then
               UNICORN_CONFIG_PATH=#{primary_config_path};
             else
@@ -128,7 +126,6 @@ module CapistranoUnicorn
 
         def duplicate_unicorn
           script = <<-END
-            set -x;
             if #{unicorn_is_running?}; then
               echo "Duplicating Unicorn...";
               #{unicorn_send_signal('USR2')};
@@ -180,7 +177,6 @@ module CapistranoUnicorn
           desc 'Reload Unicorn'
           task :reload, :roles => :app, :except => {:no_release => true} do
             run <<-END
-              set -x;
               if #{unicorn_is_running?}; then
                 echo "Reloading Unicorn...";
                 #{unicorn_send_signal('HUP')};
@@ -193,7 +189,6 @@ module CapistranoUnicorn
           desc 'Add a new worker'
           task :add_worker, :roles => :app, :except => {:no_release => true} do
             run <<-END
-              set -x;
               if #{unicorn_is_running?}; then
                 echo "Adding a new Unicorn worker...";
                 #{unicorn_send_signal('TTIN')};
@@ -206,7 +201,6 @@ module CapistranoUnicorn
           desc 'Remove amount of workers'
           task :remove_worker, :roles => :app, :except => {:no_release => true} do
             run <<-END
-              set -x;
               if #{unicorn_is_running?}; then
                 echo "Removing a Unicorn worker...";
                 #{unicorn_send_signal('TTOU')};


### PR DESCRIPTION
Removing 

```
set -x
```

because it marks properly working tasks with the "err" indicator
