### PR TITLE
Specify custom roles for unicorn tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ You can modify any of the following options in your `deploy.rb` config.
 - `unicorn_bin`             - Set unicorn executable file. Default to `unicorn`.
 - `unicorn_bundle`          - Set bundler command for unicorn. Default to `bundle`.
 - `unicorn_user`            - Launch unicorn master as the specified user. Default to `user` variable.
+- `unicorn_roles`           - Define which roles to perform unicorn recpies on. Default to `:app`.
 - `unicorn_config_path`     - Set the directory where unicorn config files reside. Default to `current_path/config`.
 - `unicorn_config_filename` - Set the filename of the unicorn config file. Not used in multistage installations. Default to `unicorn.rb`.
 

--- a/lib/capistrano-unicorn/capistrano_integration.rb
+++ b/lib/capistrano-unicorn/capistrano_integration.rb
@@ -139,27 +139,31 @@ module CapistranoUnicorn
           script
         end
 
+        def unicorn_roles
+          fetch(:unicorn_roles, :app)
+        end
+
         #
         # Unicorn cap tasks
         #
         namespace :unicorn do
           desc 'Start Unicorn master process'
-          task :start, :roles => :app, :except => {:no_release => true} do
+          task :start, :roles => unicorn_roles, :except => {:no_release => true} do
             run start_unicorn
           end
 
           desc 'Stop Unicorn'
-          task :stop, :roles => :app, :except => {:no_release => true} do
+          task :stop, :roles => unicorn_roles, :except => {:no_release => true} do
             run kill_unicorn('QUIT')
           end
 
           desc 'Immediately shutdown Unicorn'
-          task :shutdown, :roles => :app, :except => {:no_release => true} do
+          task :shutdown, :roles => unicorn_roles, :except => {:no_release => true} do
             run kill_unicorn('TERM')
           end
 
           desc 'Restart Unicorn'
-          task :restart, :roles => :app, :except => {:no_release => true} do
+          task :restart, :roles => unicorn_roles, :except => {:no_release => true} do
             run <<-END
               #{duplicate_unicorn}
 
@@ -172,12 +176,12 @@ module CapistranoUnicorn
           end
 
           desc 'Duplicate Unicorn'
-          task :duplicate, :roles => :app, :except => {:no_release => true} do
+          task :duplicate, :roles => unicorn_roles, :except => {:no_release => true} do
             run duplicate_unicorn()
           end
 
           desc 'Reload Unicorn'
-          task :reload, :roles => :app, :except => {:no_release => true} do
+          task :reload, :roles => unicorn_roles, :except => {:no_release => true} do
             run <<-END
               if #{unicorn_is_running?}; then
                 echo "Reloading Unicorn...";
@@ -189,7 +193,7 @@ module CapistranoUnicorn
           end
 
           desc 'Add a new worker'
-          task :add_worker, :roles => :app, :except => {:no_release => true} do
+          task :add_worker, :roles => unicorn_roles, :except => {:no_release => true} do
             run <<-END
               if #{unicorn_is_running?}; then
                 echo "Adding a new Unicorn worker...";
@@ -201,7 +205,7 @@ module CapistranoUnicorn
           end
 
           desc 'Remove amount of workers'
-          task :remove_worker, :roles => :app, :except => {:no_release => true} do
+          task :remove_worker, :roles => unicorn_roles, :except => {:no_release => true} do
             run <<-END
               if #{unicorn_is_running?}; then
                 echo "Removing a Unicorn worker...";


### PR DESCRIPTION
Specify custom roles for unicorn tasks, useful for custom/multistage deployments. A new implementation of #47 by @DaRizat.
