### PR TITLE
Bunch of tasks to achieve more controlled deploys

### DIFF
--- a/lib/capistrano-unicorn/capistrano_integration.rb
+++ b/lib/capistrano-unicorn/capistrano_integration.rb
@@ -242,7 +242,7 @@ module CapistranoUnicorn
               sleep #{unicorn_restart_sleep_time};
 
               if #{old_unicorn_is_running?}; then
-                #{unicorn_send_signal('WINCH', get_old_unicorn_pid)}
+                #{unicorn_send_signal('WINCH', get_old_unicorn_pid)};
               fi;
             END
           end

--- a/lib/capistrano-unicorn/capistrano_integration.rb
+++ b/lib/capistrano-unicorn/capistrano_integration.rb
@@ -241,7 +241,9 @@ module CapistranoUnicorn
 
               sleep #{unicorn_restart_sleep_time};
 
-              #{unicorn_send_signal('WINCH', get_old_unicorn_pid)}
+              if #{old_unicorn_is_running?}; then
+                #{unicorn_send_signal('WINCH', get_old_unicorn_pid)}
+              fi;
             END
           end
 


### PR DESCRIPTION
Using WINCH to shut down down old workers after some time, without killing the master in case we want to use it again(which will be achieved by sending HUP to it and making it spawn more workers). 
When we're sure that everything we can use the stop_old_master task, or do the forementioned fallback
