### PR TITLE
Fetch unicorn roles on task execution, not declaration

### DIFF
--- a/lib/capistrano-unicorn/capistrano_integration.rb
+++ b/lib/capistrano-unicorn/capistrano_integration.rb
@@ -140,7 +140,7 @@ module CapistranoUnicorn
         end
 
         def unicorn_roles
-          fetch(:unicorn_roles, :app)
+          defer{ fetch(:unicorn_roles, :app) }
         end
 
         #


### PR DESCRIPTION
As for now if one sets `:unicorn_roles` after `require 'capistrano-unicorn'` it has no effect (`:app` is used instead of set role). This little patch fixes the issue.
