### PR TITLE
Fix unicorn pid auto-detection behavior

### DIFF
--- a/lib/capistrano-unicorn/config.rb
+++ b/lib/capistrano-unicorn/config.rb
@@ -36,7 +36,16 @@ module CapistranoUnicorn
           _cset(:unicorn_config_stage_file_path) \
             { app_path + '/' + unicorn_config_stage_rel_file_path }
           _cset(:unicorn_default_pid)        { app_path + "/tmp/pids/unicorn.pid" }
-          _cset(:unicorn_pid) { extract_pid_file || unicorn_default_pid }
+          _cset(:unicorn_pid) do
+            extracted_pid = extract_pid_file
+            if extracted_pid
+              extracted_pid
+            else
+              logger.important "err :: failed to auto-detect pid from #{local_unicorn_config}"
+              logger.important "err :: falling back to default: #{unicorn_default_pid}"
+              unicorn_default_pid
+            end
+          end
       end
     end
   end

--- a/lib/capistrano-unicorn/config.rb
+++ b/lib/capistrano-unicorn/config.rb
@@ -36,16 +36,7 @@ module CapistranoUnicorn
           _cset(:unicorn_config_stage_file_path) \
             { app_path + '/' + unicorn_config_stage_rel_file_path }
           _cset(:unicorn_default_pid)        { app_path + "/tmp/pids/unicorn.pid" }
-          _cset(:unicorn_pid) do
-            extracted_pid = extract_pid_file
-            if extracted_pid
-              extracted_pid
-            else
-              logger.important "err :: failed to auto-detect pid from #{local_unicorn_config}"
-              logger.important "err :: falling back to default: #{unicorn_default_pid}"
-              unicorn_default_pid
-            end
-          end
+          _cset(:unicorn_pid) { extract_pid_file || unicorn_default_pid }
       end
     end
   end

--- a/lib/capistrano-unicorn/utility.rb
+++ b/lib/capistrano-unicorn/utility.rb
@@ -14,7 +14,7 @@ module CapistranoUnicorn
         exit 0
       EOC
 
-      pid = capture("cd #{current_path} && unicorn -e \"#{code}\"", :roles => unicorn_roles).rstrip
+      pid = capture("cd #{app_path} && unicorn -e \"#{code}\"", :roles => unicorn_roles).rstrip
       pid == "unset" ? nil : File.expand_path(pid, app_path)
     end
 


### PR DESCRIPTION
- run auto-detection on remote
- convert relative path to absolute
- use `unicorn -e` instead of `unicorn -c` with Tempfile

This fixes #85
