### PR TITLE
[Bugfix] Assign unicorn rack environment same as rails env

### DIFF
--- a/lib/capistrano-unicorn/config.rb
+++ b/lib/capistrano-unicorn/config.rb
@@ -6,7 +6,7 @@ module CapistranoUnicorn
         _cset(:unicorn_env)                { fetch(:rails_env, 'production' ) }
         _cset(:unicorn_rack_env) do
           # Following recommendations from http://unicorn.bogomips.org/unicorn_1.html
-          fetch(:rails_env) == 'development' ? 'development' : 'deployment'
+          fetch(:rails_env) || 'deployment'
         end
 
         # Execution


### PR DESCRIPTION
@sosedoff

I ran into an error deploying to a staging environment where Unicorn would no longer start. I kept getting an error that my database configuration does not specify an adapter, which it does.

I found that currently `unicorn_rack_env` is currently set to 'development' OR 'deployment. My staging environment has a rails_env name of "staging".. so unicorn, on start, couldn't find the appropriate database configuration in my database.yml file.

I suggest altering it such that `unicorn_rack_env` is set to be the same as rails_env.
