### PR TITLE
Fix SyntaxError with utility.rb and Ruby 1.8.7

### DIFF
--- a/lib/capistrano-unicorn/utility.rb
+++ b/lib/capistrano-unicorn/utility.rb
@@ -3,8 +3,8 @@ module CapistranoUnicorn
 
     def local_unicorn_config
       File.exist?(unicorn_config_rel_file_path) ?
-          unicorn_config_rel_file_path
-        : unicorn_config_stage_rel_file_path
+          unicorn_config_rel_file_path :
+          unicorn_config_stage_rel_file_path
     end
 
     def extract_pid_file


### PR DESCRIPTION
I have to work with Ruby 1.8.7 (long story, legacy project) and having the colon on the new line makes the deploy throw an error at the very beginning of the process:
~/.rvm/gems/ruby-1.8.7-p370/gems/capistrano-unicorn-0.2.0/lib/capistrano-unicorn/utility.rb:6: syntax error, unexpected '\n' (SyntaxError)

Moving the colon to the end of the previous line solves the problem for Ruby 1.8.7, and for any newer Ruby version is just a cosmetic change.
